### PR TITLE
Avoid duplicate initialization of manual calculator

### DIFF
--- a/lp/net-worth.html
+++ b/lp/net-worth.html
@@ -548,6 +548,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   let assetRange = '';
   let stepOrder = ['1'];
   let currentIndex = 0;
+  let manualInitialized = false;
   
   // Manual calculation data
   let manualData = {
@@ -758,6 +759,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   }
 
   function initializeManualCalculation() {
+    if (manualInitialized) return;
+    manualInitialized = true;
+
     // Set up slider event listeners with proper key mapping
     const sliderConfigs = [
       { type: 'cash', key: 'cash' },


### PR DESCRIPTION
## Summary
- prevent duplicate event listeners by ensuring manual calculator setup runs only once

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a347f4e21083328898a213aae55693