### PR TITLE
style: improve net worth option buttons

### DIFF
--- a/lp/net-worth.html
+++ b/lp/net-worth.html
@@ -20,9 +20,12 @@
     .progress-label { text-align: center; font-size: 0.9rem; color: #3f6b5d; margin-bottom: 1rem; height: 0; overflow: hidden; }
     .question { font-size: 1.4rem; font-weight: bold; margin-bottom: 0.5rem; color: #333; }
     .subtext { font-size: 0.95rem; color: #666; margin-bottom: 1.25rem; }
-    .grid-buttons { display: flex; flex-direction: column; gap: 0.75rem; }
-    .option-button, .submit-button { padding: 1rem; font-size: 1rem; background-color: #f5f5f5; color: #333; border: 2px solid #ddd; border-radius: 30px; cursor: pointer; font-weight: bold; transition: background-color 0.2s, border-color 0.2s; }
-    .option-button:hover, .submit-button:hover { background-color: #e0e0e0; border-color: #3f6b5d; }
+    .grid-buttons { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem; }
+    .option-button, .submit-button { padding: 1rem; font-size: 1rem; width: 100%; box-sizing: border-box; border-radius: 8px; cursor: pointer; font-weight: bold; border: 2px solid #3f6b5d; transition: background-color 0.2s, color 0.2s; }
+    .option-button { background-color: #fff; color: #3f6b5d; }
+    .option-button:hover, .option-button.active { background-color: #3f6b5d; color: #fff; }
+    .submit-button { background-color: #3f6b5d; color: #fff; }
+    .submit-button:hover { background-color: #33594b; }
     .top-bar { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 1rem; }
     .nav-links { display: flex; gap: 1rem; }
     .nav-links a { color: #888; text-decoration: none; cursor: pointer; }
@@ -77,10 +80,11 @@
       margin-top: 1.5rem; 
       flex-direction: row; 
     }
-    .exit-btn-secondary { 
-      flex: 1; 
-      background-color: #f5f5f5; 
-      border: 2px solid #ddd; 
+    .exit-btn-secondary {
+      flex: 1;
+      background-color: #f5f5f5;
+      border: 2px solid #ddd;
+      color: #333;
     }
     .exit-btn-primary { 
       flex: 1; 
@@ -1276,6 +1280,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     document.getElementById('overlay').addEventListener('click', function() {
       closeHelp();
       closeExitConfirm();
+    });
+
+    document.querySelectorAll('.grid-buttons').forEach(container => {
+      container.addEventListener('click', function(e) {
+        if (e.target.classList.contains('option-button')) {
+          container.querySelectorAll('.option-button').forEach(btn => btn.classList.remove('active'));
+          e.target.classList.add('active');
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Style net-worth wizard buttons with brand colors and grid layout
- Highlight selected option on click for better visibility

## Testing
- `npx --yes htmlhint lp/net-worth.html` *(fails: duplicate id values and missing img src)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3bce3c08332864661d0b9c46d3d