### PR TITLE
feat: add Empower click value scoring

### DIFF
--- a/expense-ratio-calculator.html
+++ b/expense-ratio-calculator.html
@@ -292,6 +292,17 @@
     function redirectToEmpower() {
       const sabeid = getOrCreateUserId();
       const gclid = getGclid();
+
+      // Track the redirect with default value when assets are unknown
+      if (typeof dataLayer !== 'undefined') {
+        dataLayer.push({
+          'event': 'redirect_click',
+          'redirect_destination': 'empower',
+          'user_id': sabeid,
+          'value': 5
+        });
+      }
+
       const baseUrl = 'https://track.flexlinkspro.com/g.ashx?foid=156074.13439.1058727&trid=1368848.157618&foc=16&fot=9999&fos=6';
       const url = `${baseUrl}&fobs=${sabeid}&fobs2=${gclid}`;
       window.open(url, '_blank');

--- a/lp/net-worth.html
+++ b/lp/net-worth.html
@@ -574,6 +574,28 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     otherDebt: 0
   };
 
+  function getEmpowerClickValue(range, liquidAssets) {
+    if (typeof liquidAssets === 'number' && !isNaN(liquidAssets)) {
+      if (liquidAssets >= 200000) return 20;
+      if (liquidAssets >= 100000) return 10;
+      return 2;
+    }
+
+    switch (range) {
+      case '$500k–$1m':
+      case '$1m+':
+        return 20;
+      case '$100k–$500k':
+        return 10;
+      case '<$10k':
+      case '$10k–$50k':
+      case '$50k–$100k':
+        return 2;
+      default:
+        return 5;
+    }
+  }
+
   // Logarithmic slider configuration
   const sliderRanges = {
     cash: { min: 0, max: 500000, center: 25000 }, // $0 to $500k, center at $25k
@@ -1024,15 +1046,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   function redirectToEmpower() {
     trackFormEvent('net-worth', '3', 'click', 'continue');
-    
+
     // Track the redirect event
+    const value = getEmpowerClickValue(assetRange);
     if (typeof dataLayer !== 'undefined') {
       dataLayer.push({
         'event': 'redirect_click',
         'redirect_destination': 'empower',
         'user_id': getOrCreateUserId(),
         'asset_range': assetRange,
-        'calculation_mode': calculationMode
+        'calculation_mode': calculationMode,
+        'value': value
       });
     }
     
@@ -1105,15 +1129,18 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   function redirectToEmpowerManual() {
     trackFormEvent('net-worth', 'manual-empower', 'click', 'continue');
-    
+
     // Track the redirect event
+    const liquidAssets = manualData.cash + manualData.investments;
+    const value = getEmpowerClickValue(null, liquidAssets);
     if (typeof dataLayer !== 'undefined') {
       dataLayer.push({
         'event': 'redirect_click',
         'redirect_destination': 'empower',
         'user_id': getOrCreateUserId(),
         'asset_range': 'manual_calculation',
-        'calculation_mode': calculationMode
+        'calculation_mode': calculationMode,
+        'value': value
       });
     }
     
@@ -1208,9 +1235,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         'calculation_mode': calculationMode
       });
     }
-    
+
     // Redirect to exit page with financial tool options
-    window.location.href = '/lp/nw-exit.html';
+    let query = '';
+    const hasManualData = manualData.cash > 0 || manualData.investments > 0;
+    if (hasManualData) {
+      const liquidAssets = manualData.cash + manualData.investments;
+      query = `?liquidAssets=${liquidAssets}`;
+    } else if (assetRange) {
+      query = `?assetRange=${encodeURIComponent(assetRange)}`;
+    }
+    window.location.href = '/lp/nw-exit.html' + query;
   }
 
   function getHelpContent() {

--- a/lp/nw-exit.html
+++ b/lp/nw-exit.html
@@ -303,13 +303,40 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     return gclid || '';
   }
 
+  function getEmpowerClickValueFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    const liquid = parseFloat(params.get('liquidAssets'));
+    if (!isNaN(liquid)) {
+      if (liquid >= 200000) return 20;
+      if (liquid >= 100000) return 10;
+      return 2;
+    }
+
+    const range = params.get('assetRange');
+    switch (range) {
+      case '$500k–$1m':
+      case '$1m+':
+        return 20;
+      case '$100k–$500k':
+        return 10;
+      case '<$10k':
+      case '$10k–$50k':
+      case '$50k–$100k':
+        return 2;
+      default:
+        return 5;
+    }
+  }
+
   function redirectToEmpower() {
     // Track the redirect event
+    const value = getEmpowerClickValueFromURL();
     if (typeof dataLayer !== 'undefined') {
       dataLayer.push({
         'event': 'redirect_click',
         'redirect_destination': 'empower',
-        'user_id': getOrCreateUserId()
+        'user_id': getOrCreateUserId(),
+        'value': value
       });
     }
     


### PR DESCRIPTION
## Summary
- add value scoring for Empower clicks in expense ratio calculator
- score Empower clicks on net worth and exit pages based on liquid assets
- pass asset estimates to exit page for accurate click valuation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8997000008332a2d30ddf99f0cdef